### PR TITLE
Enable Moodle Plugin CI GitHub Actions.

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -1,0 +1,136 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: 8.4
+            moodle-branch: MOODLE_500_STABLE
+            database: pgsql
+          - php: 8.4
+            moodle-branch: MOODLE_500_STABLE
+            database: mariadb
+
+          - php: 8.3
+            moodle-branch: MOODLE_500_STABLE
+            database: pgsql
+          - php: 8.3
+            moodle-branch: MOODLE_500_STABLE
+            database: mariadb
+          - php: 8.3
+            moodle-branch: MOODLE_405_STABLE
+            database: pgsql
+          - php: 8.3
+            moodle-branch: MOODLE_405_STABLE
+            database: mariadb
+
+          - php: 8.2
+            moodle-branch: MOODLE_500_STABLE
+            database: pgsql
+          - php: 8.2
+            moodle-branch: MOODLE_500_STABLE
+            database: mariadb
+          - php: 8.2
+            moodle-branch: MOODLE_405_STABLE
+            database: pgsql
+          - php: 8.2
+            moodle-branch: MOODLE_405_STABLE
+            database: mariadb
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+          submodules: true
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: |
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+          IGNORE_PATHS: moodle/tests/fixtures,moodle/Sniffs
+
+      - name: PHP Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker --max-warnings 0
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      - name: Grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit
+
+      - name: Behat features
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Moodle Plugin CI](https://github.com/edu-sharing/moodle-mod_edusharing/actions/workflows/moodle-plugin-ci.yml/badge.svg)](https://github.com/edu-sharing/moodle-mod_edusharing/actions/workflows/moodle-plugin-ci.yml)
 # edu-sharing activity module
 
 The edu-sharing activity module adds a new option to the activities/resource menu. Using the edu-sharing resource allows you to either pick content from the repository or upload it to a folder of the repository. You may pick which version of the content you would like to provide in the course (always the latest vs. the version you just picked).

--- a/db/access.php
+++ b/db/access.php
@@ -33,7 +33,6 @@ $capabilities = [
         'archetypes'   => [
             'editingteacher' => CAP_ALLOW,
             'manager'        => CAP_ALLOW,
-            'admin'          => CAP_ALLOW,
             'teacher'        => CAP_ALLOW,
         ],
         'clonepermissionsfrom' => 'moodle/course:manageactivities',
@@ -45,7 +44,6 @@ $capabilities = [
             'coursecreator' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
             'manager'        => CAP_ALLOW,
-            'admin'          => CAP_ALLOW,
             'teacher'        => CAP_ALLOW,
         ],
     ],

--- a/import_metadata.php
+++ b/import_metadata.php
@@ -90,11 +90,13 @@ if (!empty($metadataurl)) {
         $service->import_metadata($metadataurl);
         echo '<h3 class="edu_success">Import successful.</h3>';
     } catch (EduSharingUserException $edusharinguserexception) {
+        debugging('Edusharing error importing metatada from repo: ' . $edusharinguserexception->getMessage());
         echo $edusharinguserexception->get_html_message();
     } catch (Exception $exception) {
+        debugging('General error importing metatada from repo: ' . $exception->getMessage());
         echo '<p style="background: #FF8170">Unexpected error - please try again later<br></p>';
     }
-    if ($service->reloadform) {
+    if (isset($service) && $service->reloadform) {
         echo MetaDataFrontend::get_meta_data_form();
     }
     $repoform = MetaDataFrontend::get_repo_form();

--- a/metadata.php
+++ b/metadata.php
@@ -27,6 +27,8 @@ use mod_edusharing\EduSharingService;
 use mod_edusharing\MetadataLogic;
 use mod_edusharing\UtilityFunctions;
 
+// Require_login is not needed here.
+// phpcs:disable moodle.Files.RequireLogin.Missing
 
 require_once(dirname(__FILE__) . '/../../config.php');
 

--- a/tests/edusharing_service_test.php
+++ b/tests/edusharing_service_test.php
@@ -91,7 +91,7 @@ final class edusharing_service_test extends \advanced_testcase {
             ->getMock();
         $authmock->expects($this->once())
             ->method('getTicketAuthenticationInfo')
-            ->will($this->returnValue(['statusCode' => 'OK']));
+            ->willReturn(['statusCode' => 'OK']);
         $nodeconfig  = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $nodehandler = new EduSharingNodeHelper($basehelper, $nodeconfig);
         $service     = new EduSharingService($authmock, $nodehandler);
@@ -119,13 +119,13 @@ final class edusharing_service_test extends \advanced_testcase {
             ->getMock();
         $authmock->expects($this->once())
             ->method('getTicketForUser')
-            ->will($this->returnValue('ticketForUser'));
+            ->willReturn('ticketForUser');
         $utilsmock = $this->getMockBuilder(UtilityFunctions::class)
             ->onlyMethods(['get_auth_key'])
             ->getMock();
         $utilsmock->expects($this->once())
             ->method('get_auth_key')
-            ->will($this->returnValue('neverMind'));
+            ->willReturn('neverMind');
         $nodeconfig  = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $nodehandler = new EduSharingNodeHelper($basehelper, $nodeconfig);
         $service     = new EduSharingService($authmock, $nodehandler, $utilsmock);
@@ -154,16 +154,16 @@ final class edusharing_service_test extends \advanced_testcase {
             ->getMock();
         $authmock->expects($this->once())
             ->method('getTicketForUser')
-            ->will($this->returnValue('ticketForUser'));
+            ->willReturn('ticketForUser');
         $authmock->expects($this->once())
             ->method('getTicketAuthenticationInfo')
-            ->will($this->returnValue(['statusCode' => 'NOT_OK']));
+            ->willReturn(['statusCode' => 'NOT_OK']);
         $utilsmock = $this->getMockBuilder(UtilityFunctions::class)
             ->onlyMethods(['get_auth_key'])
             ->getMock();
         $utilsmock->expects($this->once())
             ->method('get_auth_key')
-            ->will($this->returnValue('neverMind'));
+            ->willReturn('neverMind');
         $nodeconfig  = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $nodehandler = new EduSharingNodeHelper($basehelper, $nodeconfig);
         $service     = new EduSharingService($authmock, $nodehandler, $utilsmock);
@@ -196,7 +196,7 @@ final class edusharing_service_test extends \advanced_testcase {
             ->getMock();
         $servicemock->expects($this->once())
             ->method('get_ticket')
-            ->will($this->returnValue('ticketTest'));
+            ->willReturn('ticketTest');
         $servicemock->create_usage($usageobject);
     }
 
@@ -222,7 +222,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $nodehelpermock->expects($this->once())
             ->method('getUsageIdByParameters')
             ->with('ticketTest', 'nodeIdTest', 'containerIdTest', 'resourceIdTest')
-            ->will($this->returnValue('expectedId'));
+            ->willReturn('expectedId');
         $service = new EduSharingService($authhelper, $nodehelpermock);
         $id      = $service->get_usage_id($usageobject);
         $this->assertEquals('expectedId', $id);
@@ -250,7 +250,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $nodehelpermock->expects($this->once())
             ->method('getUsageIdByParameters')
             ->with('ticketTest', 'nodeIdTest', 'containerIdTest', 'resourceIdTest')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
         $service = new EduSharingService($authhelper, $nodehelpermock);
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('No usage found');
@@ -346,25 +346,25 @@ final class edusharing_service_test extends \advanced_testcase {
         $utilsmock->expects($this->once())
             ->method('get_object_id_from_url')
             ->with('inputUrl')
-            ->will($this->returnValue('outputUrl'));
+            ->willReturn('outputUrl');
         $servicemock = $this->getMockBuilder(EduSharingService::class)
             ->onlyMethods(['create_usage', 'get_ticket'])
             ->setConstructorArgs([$authhelper, $nodehelper, $utilsmock])
             ->getMock();
         $servicemock->expects($this->once())
             ->method('get_ticket')
-            ->will($this->returnValue('ticketTest'));
+            ->willReturn('ticketTest');
         $servicemock->expects($this->once())
             ->method('create_usage')
             ->with($usagedata)
-            ->will($this->returnValue(new Usage('whatever', 'whatever', 'whatever', 'whatever', '2')));
+            ->willReturn(new Usage('whatever', 'whatever', 'whatever', 'whatever', '2'));
         $dbmock = $this->getMockBuilder(moodle_database_for_testing::class)
             ->onlyMethods(['get_record', 'update_record'])
             ->getMock();
         $dbmock->expects($this->once())
             ->method('get_record')
             ->with('edusharing', ['id' => 'resourceIdTest'], '*', MUST_EXIST)
-            ->will($this->returnValue($memento));
+            ->willReturn($memento);
         $dbmock->expects($this->once())
             ->method('update_record')
             ->with('edusharing', $eduobjectupdate);
@@ -412,14 +412,14 @@ final class edusharing_service_test extends \advanced_testcase {
         $utilsmock->expects($this->once())
             ->method('get_object_id_from_url')
             ->with('inputUrl')
-            ->will($this->returnValue('outputUrl'));
+            ->willReturn('outputUrl');
         $servicemock = $this->getMockBuilder(EduSharingService::class)
             ->onlyMethods(['create_usage', 'get_ticket'])
             ->setConstructorArgs([$authhelper, $nodehelper, $utilsmock])
             ->getMock();
         $servicemock->expects($this->once())
             ->method('get_ticket')
-            ->will($this->returnValue('ticketTest'));
+            ->willReturn('ticketTest');
         $servicemock->expects($this->once())
             ->method('create_usage')
             ->with($usagedata)
@@ -430,7 +430,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $dbmock->expects($this->once())
             ->method('get_record')
             ->with('edusharing', ['id' => 'resourceIdTest'], '*', MUST_EXIST)
-            ->will($this->returnValue($memento));
+            ->willReturn($memento);
         $dbmock->expects($this->once())
             ->method('update_record')
             ->with('edusharing', $memento);
@@ -476,7 +476,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $dbmock->expects($this->once())
             ->method('insert_record')
             ->with('edusharing', $processededuobject)
-            ->will($this->returnValue(3));
+            ->willReturn(3);
         $dbmock->expects($this->once())
             ->method('update_record')
             ->with('edusharing', $insertededuobject);
@@ -488,7 +488,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $utilsmock->expects($this->once())
             ->method('get_object_id_from_url')
             ->with('inputUrl')
-            ->will($this->returnValue('outputUrl'));
+            ->willReturn('outputUrl');
         $basehelper  = new EduSharingHelperBase('www.url.de', 'pkey123', 'appid123');
         $nodeconfig  = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $authhelper  = new EduSharingAuthHelper($basehelper);
@@ -500,7 +500,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $servicemock->expects($this->once())
             ->method('create_usage')
             ->with($usagedata)
-            ->will($this->returnValue(new Usage('whatever', 'nodeVersionTest', 'whatever', 'whatever', '4')));
+            ->willReturn(new Usage('whatever', 'nodeVersionTest', 'whatever', 'whatever', '4'));
         $this->assertEquals(3, $servicemock->add_instance($eduobject));
     }
 
@@ -541,7 +541,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $dbmock->expects($this->once())
             ->method('insert_record')
             ->with('edusharing', $processededuobject)
-            ->will($this->returnValue(3));
+            ->willReturn(3);
         $dbmock->expects($this->never())
             ->method('update_record');
         $dbmock->expects($this->once())
@@ -555,7 +555,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $utilsmock->expects($this->once())
             ->method('get_object_id_from_url')
             ->with('inputUrl')
-            ->will($this->returnValue('outputUrl'));
+            ->willReturn('outputUrl');
         $basehelper  = new EduSharingHelperBase('www.url.de', 'pkey123', 'appid123');
         $nodeconfig  = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $authhelper  = new EduSharingAuthHelper($basehelper);
@@ -616,7 +616,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $dbmock->expects($this->once())
             ->method('get_record')
             ->with('edusharing', ['id' => $id], '*', MUST_EXIST)
-            ->will($this->returnValue($dbrecord));
+            ->willReturn($dbrecord);
         $dbmock->expects($this->once())
             ->method('delete_records')
             ->with('edusharing', ['id' => 'edusharingId123']);
@@ -632,17 +632,17 @@ final class edusharing_service_test extends \advanced_testcase {
         $utilsmock->expects($this->once())
             ->method('get_object_id_from_url')
             ->with('test.de')
-            ->will($this->returnValue('myNodeId123'));
+            ->willReturn('myNodeId123');
         $servicemock = $this->getMockBuilder(EduSharingService::class)
             ->setConstructorArgs([$authhelper, $nodehelper, $utilsmock])
             ->onlyMethods(['get_ticket', 'get_usage_id', 'delete_usage'])
             ->getMock();
         $servicemock->expects($this->once())
             ->method('get_ticket')
-            ->will($this->returnValue('ticket123'));
+            ->willReturn('ticket123');
         $servicemock->expects($this->once())
             ->method('get_usage_id')
-            ->will($this->returnValue('usage123'));
+            ->willReturn('usage123');
         $servicemock->delete_instance((string)$id);
     }
 
@@ -673,7 +673,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $basemock->expects($this->once())
             ->method('handleCurlRequest')
             ->with($url, $expectedoptions)
-            ->will($this->returnValue($curl));
+            ->willReturn($curl);
         $nodeconfig = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $authhelper = new EduSharingAuthHelper($basemock);
         $nodehelper = new EduSharingNodeHelper($basemock, $nodeconfig);
@@ -706,7 +706,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $basemock->expects($this->once())
             ->method('handleCurlRequest')
             ->with($url . '/rest/authentication/v1/validateSession', $expectedoptions)
-            ->will($this->returnValue($curl));
+            ->willReturn($curl);
         $nodeconfig = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $authhelper = new EduSharingAuthHelper($basemock);
         $nodehelper = new EduSharingNodeHelper($basemock, $nodeconfig);
@@ -747,7 +747,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $curlmock->expects($this->once())
             ->method('handleCurlRequest')
             ->with($url . '/rest/admin/v1/applications/xml', $curloptions)
-            ->will($this->returnValue($curl));
+            ->willReturn($curl);
         $basehelper->registerCurlHandler($curlmock);
         $nodeconfig = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $authhelper = new EduSharingAuthHelper($basehelper);
@@ -770,7 +770,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $basemock->expects($this->once())
             ->method('sign')
             ->with('testInput')
-            ->will($this->returnValue('testOutput'));
+            ->willReturn('testOutput');
         $nodeconfig = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $authhelper = new EduSharingAuthHelper($basemock);
         $nodehelper = new EduSharingNodeHelper($basemock, $nodeconfig);
@@ -806,7 +806,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $curlmock->expects($this->once())
             ->method('handleCurlRequest')
             ->with('www.testUrl.de', $curloptions)
-            ->will($this->returnValue(new CurlResult('expectedContent', 0, [])));
+            ->willReturn(new CurlResult('expectedContent', 0, []));
         $basehelper->registerCurlHandler($curlmock);
         $nodeconfig = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $authhelper = new EduSharingAuthHelper($basehelper);
@@ -840,7 +840,7 @@ final class edusharing_service_test extends \advanced_testcase {
         $curlmock->expects($this->once())
             ->method('handleCurlRequest')
             ->with('www.testUrl.de', $curloptions)
-            ->will($this->returnValue(new CurlResult('expectedContent', 1, ['message' => 'error'])));
+            ->willReturn(new CurlResult('expectedContent', 1, ['message' => 'error']));
         $basehelper->registerCurlHandler($curlmock);
         $nodeconfig = new EduSharingNodeHelperConfig(new UrlHandling(true));
         $authhelper = new EduSharingAuthHelper($basehelper);


### PR DESCRIPTION
This commits lets the automated tests for Moodle Plugin CI pass (of course you'd have to enable them in your Repository).
They now require PHPUnit 11.
Moreover, also PHP 8.4 and Moodle 5.0 are supported.
All required coding style changes and adoptions are included here.

Thanks for taking into consideration a merge.